### PR TITLE
use ::T for types in @trace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mjolnir"
 uuid = "1154507a-7ac2-44fe-9f15-34617bca9db5"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pow (generic function with 1 method)
 
 julia> using Mjolnir
 
-julia> @trace pow(Int, 3)
+julia> @trace pow(::Int, 3)
 1: (%1 :: const(pow), %2 :: Int64, %3 :: const(3))
   %4 = (*)(1, %2) :: Int64
   %5 = (*)(%4, %2) :: Int64
@@ -43,7 +43,7 @@ can generate diagnostics when there are issues. Mjolnir can thus compile a much
 wider range of Julia programs than OO approaches.
 
 ```julia
-julia> @trace pow(Int, Int)
+julia> @trace pow(::Int, ::Int)
 1: (%1 :: const(pow), %2 :: Int64, %3 :: Int64)
   %4 = (>)(%3, 0) :: Bool
   br 3 (1) unless %4

--- a/docs/types.md
+++ b/docs/types.md
@@ -47,7 +47,7 @@ functions are called _primitives_.
 julia> f(x) = 3x^2 + 2x + 1
 f (generic function with 1 method)
 
-julia> @trace f(Int)
+julia> @trace f(::Int)
 1: (%1 :: const(f), %2 :: Int64)
   %3 = (*)(%2, %2) :: Int64
   %4 = (*)(3, %3) :: Int64
@@ -144,7 +144,7 @@ julia> @abstract MyPrimitives (a::AType{T} * b::AType{T}) where T<:Union{Float64
 
 julia> MyDefaults() = Multi(MyPrimitives(), Mjolnir.Basic())
 
-julia> @trace MyDefaults() Int * Float64
+julia> @trace MyDefaults() ::Int * ::Float64
 1: (%1 :: const(*), %2 :: Int64, %3 :: Float64)
   %4 = ($(QuoteNode(Float64)))(%2) :: Float64
   %5 = (*)(%4, %3) :: Float64

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -267,12 +267,17 @@ function trace(P, Ts...)
   end
 end
 
+to_type_level(x) = :(Mjolnir.Const($x))
+to_type_level(ex::Expr) = isexpr(ex, :(::)) && length(ex.args) == 1 ? (ex.args[1]) : :(Mjolnir.Const($ex)) 
+
 atype(T::AType) = T
 atype(x) = Const(x)
+#atype.(($(esc(f)), $(esc.(args)...)))...)
 
 function tracem(P, ex)
   @capture(ex, f_(args__)) || error("@trace f(args...)")
-  :(trace($(esc(P)), atype.(($(esc(f)), $(esc.(args)...)))...))
+  sig = ((esc ∘ to_type_level).((f, args...)))  
+  :(trace($(esc(P)), $(sig...)))
 end
 
 """

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -287,7 +287,7 @@ end
 Get a typed trace for `f`, analagous to `@code_typed`. Note that unlike
 `@code_typed`, you probably want to pass types rather than values, e.g.
 
-    julia> @trace Int+Int
+    julia> @trace ::Int + ::Int
     1: (%1 :: const(+), %2 :: Int64, %3 :: Int64)
       %4 = (+)(%2, %3) :: Int64
       return %4

--- a/test/trace.jl
+++ b/test/trace.jl
@@ -64,7 +64,7 @@ ir = @code_ir fact(1)
 tr = @trace f()
 @test returntype(tr) == String
 
-tr = @trace pow(Int, 3)
+tr = @trace pow(::Int, 3)
 @test length(tr.blocks) == 1
 @test returntype(tr) == Int
 
@@ -72,16 +72,16 @@ tr = @trace pow(2, 3)
 @test length(tr.blocks) == 1
 @test returntype(tr) == Const(8)
 
-tr = @trace pow(2, Int)
+tr = @trace pow(2, ::Int)
 @test returntype(tr) == Int
 
-tr = @trace pow(2.0, Int)
+tr = @trace pow(2.0, ::Int)
 @test returntype(tr) == Union{Float64,Int}
 
-tr = @trace pow(1, Int)
+tr = @trace pow(1, ::Int)
 @test returntype(tr) == Const(1)
 
-tr = @trace bar(Int, Int)
+tr = @trace bar(::Int, ::Int)
 @test returntype(tr) == Int
 
 function foo(x)
@@ -93,7 +93,7 @@ end
 tr = @trace foo(1)
 @test returntype(tr) == Const(1)
 
-tr = @trace foo(Int)
+tr = @trace foo(::Int)
 @test returntype(tr) == Int
 
 function foo(x)
@@ -142,7 +142,7 @@ end
 tr = @trace pow(2, 3)
 @test returntype(tr) == Const(8)
 
-tr = @trace pow(Int, Int)
+tr = @trace pow(::Int, ::Int)
 @test returntype(tr) == Int
 
 function sumabs2(xs)
@@ -153,14 +153,14 @@ function sumabs2(xs)
   return s
 end
 
-tr = @trace sumabs2(arrayshape(Float64, 3))
+tr = @trace sumabs2(::arrayshape(Float64, 3))
 @test length(blocks(tr)) == 1
 @test returntype(tr) == Float64
 
 f(xs) = sum(xs)
-tr = @trace f(Matrix{Int32})
+tr = @trace f(::Matrix{Int32})
 @test returntype(tr) == Int32
 
 f(xs) = sum(xs, dims = 1)
-tr = @trace f(Matrix{Int32})
+tr = @trace f(::Matrix{Int32})
 @test returntype(tr) == Matrix{Int32}


### PR DESCRIPTION
closes https://github.com/MikeInnes/Mjolnir.jl/issues/9

I incremented the version because this is a breaking change.
```julia
using Mjolnir

@trace sin(::Real)

#+RESULTS:
: 1: (%1 :: const(sin), %2 :: Real)
:   %3 = (sin)(%2)
:   return %3
```
```julia
@trace sin(1)

#+RESULTS:
: 1: (%1 :: const(sin), %2 :: const(1))
:   return 0.8414709848078965
```
```julia
@trace sin(::Mjolnir.Const(1))

#+RESULTS:
: 1: (%1 :: const(sin), %2 :: const(1))
:   return 0.8414709848078965
```