### PR TITLE
support doing inference on more kinds of exprs

### DIFF
--- a/src/infer.jl
+++ b/src/infer.jl
@@ -211,7 +211,12 @@ function step!(inf::Inference)
 end
 
 function infer_stmt!(inf, frame, b, f, ip, block, var, st)
-  println(st)
+  if st.expr isa QuoteNode
+    block.ir[var] = stmt(block[var], type = Const(st.expr.value))
+    push!(inf.queue, (frame, b, f, ip+1))
+    return inf
+  end
+
   st.expr isa Expr || error("Unrecognised expression $(st.expr)")
   infer_stmt!(Val(st.expr.head), inf, frame, b, f, ip, block, var, st)
 end


### PR DESCRIPTION
this PR implements a new overloadable function to handle different kinds of expressions. I need this PR to support type inference in YaoLang, since I didn't find an easy way to manipulate Julia's typed IR.

Also, this fixes a bug in the current master, when you try to type infer `first(2:3)` it errors since
`IRTools` converts `static_parameter` expression to a quote node (I assume `QuoteNode` is used as some sort of `Const` in untyped IR in IRTools?)
so I think simply mark the value inside `QuoteNode` as `Const` would solve the problem.

update: I'll add some tests later.
