### PR TITLE
Use copy instead of deepcopy

### DIFF
--- a/src/trace.jl
+++ b/src/trace.jl
@@ -15,7 +15,7 @@ function getir(tr::Trace, Ts...)
   m == nothing && return
   key = Base.isgenerated(m.method) ? Ts : (m.method, m.sparams)
   ir = get!(() -> IR(m, prune = false), tr.ircache, key)
-  return deepcopy(ir)
+  return copy(ir)
 end
 
 function node!(tr::Trace, T::Union{Partial,Shape}, v)


### PR DESCRIPTION
This fixes #32 for Julia 1.6, but I'm not sure if this is the right solution (it would seem so, since IRTools specializes copy for `IRTools.IR`).